### PR TITLE
[Refactor/#16] 대표자/참여자 분할 결제 도입

### DIFF
--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -19,7 +19,7 @@ const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
     }
   };
 
-  const handlePayment = async () => {
+  const handlePayment = async (isRepresentative: boolean) => {
     const clientKey = process.env.NEXT_PUBLIC_TOSS_CLIENT_KEY;
 
     if (!clientKey) {
@@ -29,13 +29,26 @@ const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
 
     const tossPayments = await loadTossPayments(clientKey);
 
-    await tossPayments.requestPayment("카드", {
-      amount: product.price / participants, // 인원 수에 따라 금액 나누기
-      orderId: `${product.id}_${Date.now()}`,
-      orderName: product.title,
-      successUrl: `${window.location.origin}/api/payments`,
-      failUrl: `${window.location.origin}/api/payments/fail`,
-    });
+    if (isRepresentative) {
+      // 대표 구매자 결제
+      await tossPayments.requestPayment("카드", {
+        amount: product.price, // 전체 금액
+        orderId: `${product.id}_${Date.now()}`,
+        orderName: product.title,
+        successUrl: `${window.location.origin}/api/payments`,
+        failUrl: `${window.location.origin}/api/payments/fail`,
+      });
+    } else {
+      // 분할 결제 구매자 결제
+      const amountToPay = product.price / (maxParticipants - 1); // 나누어진 금액
+      await tossPayments.requestPayment("카드", {
+        amount: amountToPay,
+        orderId: `${product.id}_${Date.now()}`,
+        orderName: product.title,
+        successUrl: `${window.location.origin}/api/payments`,
+        failUrl: `${window.location.origin}/api/payments/fail`,
+      });
+    }
   };
 
   return (
@@ -68,15 +81,24 @@ const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
           참여하기
         </button>
       </div>
-      <button
-        onClick={participants === maxParticipants ? handlePayment : undefined}
-        className={`mt-2 w-full ${
-          participants < maxParticipants ? "bg-gray-400" : "bg-blue-500"
-        } text-white px-4 py-2 rounded-lg`}
-        disabled={participants < maxParticipants}
-      >
-        {participants < maxParticipants ? "모집 중..." : "결제하기"}
-      </button>
+      <div className="mt-4">
+        {participants >= 2 && (
+          <button
+            onClick={() => handlePayment(true)} // 대표자 결제
+            className="mt-2 w-full bg-blue-500 text-white px-4 py-2 rounded-lg"
+          >
+            대표자로 결제하기
+          </button>
+        )}
+        {participants >= 3 && (
+          <button
+            onClick={() => handlePayment(false)} // 참여자 결제
+            className="mt-2 w-full bg-green-500 text-white px-4 py-2 rounded-lg"
+          >
+            참여자로 결제하기
+          </button>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -40,7 +40,7 @@ const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
       });
     } else {
       // 분할 결제 구매자 결제
-      const amountToPay = product.price / (maxParticipants - 1); // 나누어진 금액
+      const amountToPay = product.price / maxParticipants; // 나누어진 금액
       await tossPayments.requestPayment("카드", {
         amount: amountToPay,
         orderId: `${product.id}_${Date.now()}`,
@@ -82,22 +82,32 @@ const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
         </button>
       </div>
       <div className="mt-4">
-        {participants >= 2 && (
-          <button
-            onClick={() => handlePayment(true)} // 대표자 결제
-            className="mt-2 w-full bg-blue-500 text-white px-4 py-2 rounded-lg whitespace-nowrap overflow-hidden truncate"
-          >
-            대표자 결제
-          </button>
-        )}
-        {participants >= 3 && (
-          <button
-            onClick={() => handlePayment(false)} // 참여자 결제
-            className="mt-2 w-full bg-green-500 text-white px-4 py-2 rounded-lg whitespace-nowrap overflow-hidden truncate"
-          >
-            참여자 결제
-          </button>
-        )}
+        <button
+          onClick={
+            participants === maxParticipants
+              ? () => handlePayment(true)
+              : undefined
+          } // 대표자 결제
+          className={`mt-2 w-full ${
+            participants < maxParticipants ? "bg-gray-400" : "bg-blue-500"
+          } text-white px-4 py-2 rounded-lg`}
+          disabled={participants < maxParticipants}
+        >
+          {participants < maxParticipants ? "모집 중..." : "대표자 결제"}
+        </button>
+        <button
+          onClick={
+            participants === maxParticipants
+              ? () => handlePayment(false)
+              : undefined
+          } // 참여자 결제
+          className={`mt-2 w-full ${
+            participants < maxParticipants ? "bg-gray-400" : "bg-blue-500"
+          } text-white px-4 py-2 rounded-lg`}
+          disabled={participants < maxParticipants}
+        >
+          {participants < maxParticipants ? "모집 중..." : "참여자 결제"}
+        </button>
       </div>
     </div>
   );

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -71,7 +71,7 @@ const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
       </div>
       <div className="mt-2">
         <p>
-          현재 참여 인원: {participants} / {maxParticipants}
+          참여 인원: {participants} / {maxParticipants}
         </p>
         <button
           onClick={handleJoin}
@@ -85,17 +85,17 @@ const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
         {participants >= 2 && (
           <button
             onClick={() => handlePayment(true)} // 대표자 결제
-            className="mt-2 w-full bg-blue-500 text-white px-4 py-2 rounded-lg"
+            className="mt-2 w-full bg-blue-500 text-white px-4 py-2 rounded-lg whitespace-nowrap overflow-hidden truncate"
           >
-            대표자로 결제하기
+            대표자 결제
           </button>
         )}
         {participants >= 3 && (
           <button
             onClick={() => handlePayment(false)} // 참여자 결제
-            className="mt-2 w-full bg-green-500 text-white px-4 py-2 rounded-lg"
+            className="mt-2 w-full bg-green-500 text-white px-4 py-2 rounded-lg whitespace-nowrap overflow-hidden truncate"
           >
-            참여자로 결제하기
+            참여자 결제
           </button>
         )}
       </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#16 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

대표자/참여자에 따른 분할 결제 도입
인원 충족 시 대표자/참여자 버튼 각각 활성화

![image](https://github.com/user-attachments/assets/9cf0da57-9fbe-4050-9e74-8e7452ac7dce)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
